### PR TITLE
Fatal errors resolved

### DIFF
--- a/includes/class-wcs-import-admin.php
+++ b/includes/class-wcs-import-admin.php
@@ -60,7 +60,9 @@ class WCS_Import_Admin {
 
 				$file_id = absint( $_GET['file_id'] );
 				$file    = get_attached_file( $file_id );
-				$enc     = mb_detect_encoding( $file, 'UTF-8, ISO-8859-1', true );
+
+				// Check if the function mb_detect_encoding exists. The function does not found if the mbstring extension is not installed on the server.
+				$enc     = function_exists('mb_detect_encoding') ? mb_detect_encoding( $file, 'UTF-8, ISO-8859-1', true ) : false;
 
 				if ( $enc ) {
 					setlocale( LC_ALL, 'en_US.' . $enc );
@@ -289,7 +291,8 @@ class WCS_Import_Admin {
 		$file    = get_attached_file( $file_id );
 
 		if ( $file ) {
-			$enc = mb_detect_encoding( $file, 'UTF-8, ISO-8859-1', true );
+			// Check if the function mb_detect_encoding exists. The function does not found if the mbstring extension is not installed on the server.
+			$enc = function_exists('mb_detect_encoding') ? mb_detect_encoding( $file, 'UTF-8, ISO-8859-1', true ) : false;
 
 			if ( $enc ) {
 				setlocale( LC_ALL, 'en_US.' . $enc );

--- a/includes/class-wcs-import-admin.php
+++ b/includes/class-wcs-import-admin.php
@@ -61,7 +61,7 @@ class WCS_Import_Admin {
 				$file_id = absint( $_GET['file_id'] );
 				$file    = get_attached_file( $file_id );
 
-				// Check if the function mb_detect_encoding exists. The function does not found if the mbstring extension is not installed on the server.
+				// Check if the function mb_detect_encoding exists. The function is not found if the mbstring extension is not installed on the server.
 				$enc     = function_exists('mb_detect_encoding') ? mb_detect_encoding( $file, 'UTF-8, ISO-8859-1', true ) : false;
 
 				if ( $enc ) {
@@ -291,7 +291,7 @@ class WCS_Import_Admin {
 		$file    = get_attached_file( $file_id );
 
 		if ( $file ) {
-			// Check if the function mb_detect_encoding exists. The function does not found if the mbstring extension is not installed on the server.
+			// Check if the function mb_detect_encoding exists. The function is not found if the mbstring extension is not installed on the server.
 			$enc = function_exists('mb_detect_encoding') ? mb_detect_encoding( $file, 'UTF-8, ISO-8859-1', true ) : false;
 
 			if ( $enc ) {

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -128,7 +128,8 @@ class WCS_Importer {
 	 */
 	public static function import_start( $file_path, $start_position, $end_position ) {
 
-		$file_encoding = mb_detect_encoding( $file_path, 'UTF-8, ISO-8859-1', true );
+		// Check if the function mb_detect_encoding exists. The function does not found if the mbstring extension is not installed on the server.
+		$file_encoding = function_exists('mb_detect_encoding') ? mb_detect_encoding( $file_path, 'UTF-8, ISO-8859-1', true ) : false;
 
 		if ( $file_encoding ) {
 			setlocale( LC_ALL, 'en_US.' . $file_encoding );

--- a/includes/wcsi-functions.php
+++ b/includes/wcsi-functions.php
@@ -8,7 +8,9 @@
  * @param string $file_encoding
  */
 function wcsi_format_data( $data, $file_encoding = 'UTF-8' ) {
-	return ( 'UTF-8' == $file_encoding ) ? $data : utf8_encode( $data );
+	// Check if the function utf8_encode( $data ) exists. The function does not found if the php-xml extension is not installed on the server.
+	$return = function_exists('utf8_encode') ? utf8_encode( $data ) : $data;
+	return ( 'UTF-8' == $file_encoding ) ? $data : $return;
 }
 
 /**

--- a/includes/wcsi-functions.php
+++ b/includes/wcsi-functions.php
@@ -8,7 +8,7 @@
  * @param string $file_encoding
  */
 function wcsi_format_data( $data, $file_encoding = 'UTF-8' ) {
-	// Check if the function utf8_encode( $data ) exists. The function does not found if the php-xml extension is not installed on the server.
+	// Check if the function utf8_encode exists. The function does not found if the php-xml extension is not installed on the server.
 	$return = function_exists('utf8_encode') ? utf8_encode( $data ) : $data;
 	return ( 'UTF-8' == $file_encoding ) ? $data : $return;
 }

--- a/includes/wcsi-functions.php
+++ b/includes/wcsi-functions.php
@@ -8,7 +8,7 @@
  * @param string $file_encoding
  */
 function wcsi_format_data( $data, $file_encoding = 'UTF-8' ) {
-	// Check if the function utf8_encode exists. The function does not found if the php-xml extension is not installed on the server.
+	// Check if the function utf8_encode exists. The function is not found if the php-xml extension is not installed on the server.
 	$return = function_exists('utf8_encode') ? utf8_encode( $data ) : $data;
 	return ( 'UTF-8' == $file_encoding ) ? $data : $return;
 }

--- a/wcs-importer-exporter.php
+++ b/wcs-importer-exporter.php
@@ -115,16 +115,16 @@ class WCS_Importer_Exporter {
 		if ( ! class_exists( 'WC_Subscriptions' ) || ! class_exists( 'WC_Subscriptions_Admin' ) ) :
 			if ( is_woocommerce_active() ) : ?>
 				<div id="message" class="error">
-					<p><?php printf( esc_html__( '%1$sWooCommerce Subscriptions Importer is inactive.%2$s The %3$sWooCommerce Subscriptions plugin%4$s must be active for WooCommerce Subscriptions Importer to work. Please %5$sinstall & activate%6$s WooCommerce.', 'wcs-import-export' ), '<strong>', '</strong>', '<a href="http://www.woocommerce.com/products/woocommerce-subscriptions/">', '</a>', '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '</a>' ); ?></p>
+					<p><?php printf( esc_html__( '%1$sWooCommerce Subscriptions CSV Importer and Exporter is inactive.%2$s The %3$sWooCommerce Subscriptions plugin%4$s must be active for WooCommerce Subscriptions CSV Importer and Exporter to work. Please %5$sinstall & activate%6$s WooCommerce.', 'wcs-import-export' ), '<strong>', '</strong>', '<a href="http://www.woocommerce.com/products/woocommerce-subscriptions/">', '</a>', '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '</a>' ); ?></p>
 				</div>
 			<?php else : ?>
 				<div id="message" class="error">
-					<p><?php printf( esc_html__( '%1$sWooCommerce Subscriptions Importer is inactive.%2$s Both %3$sWooCommerce%4$s and %5$sWooCommerce Subscriptions%6$s plugins must be active for WooCommerce Subscriptions Importer to work. Please %7$sinstall & activate%8$s these plugins before continuing.', 'wcs-import-export' ), '<strong>', '</strong>', '<a href="http://wordpress.org/extend/plugins/woocommerce/">', '</a>', '<a href="http://www.woocommerce.com/products/woocommerce-subscriptions/">', '</a>', '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '</a>' ); ?></p>
+					<p><?php printf( esc_html__( '%1$sWooCommerce Subscriptions CSV Importer and Exporter is inactive.%2$s Both %3$sWooCommerce%4$s and %5$sWooCommerce Subscriptions%6$s plugins must be active for WooCommerce Subscriptions CSV Importer and Exporter to work. Please %7$sinstall & activate%8$s these plugins before continuing.', 'wcs-import-export' ), '<strong>', '</strong>', '<a href="http://wordpress.org/extend/plugins/woocommerce/">', '</a>', '<a href="http://www.woocommerce.com/products/woocommerce-subscriptions/">', '</a>', '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '</a>' ); ?></p>
 				</div>
 			<?php endif;?>
 		<?php elseif ( ! class_exists( 'WC_Subscriptions' ) || version_compare( WC_Subscriptions::$version, self::$required_subscriptions_version, '<' ) ) : ?>
 			<div id="message" class="error">
-				<p><?php printf( esc_html__( '%1$sWooCommerce Subscriptions Importer is inactive.%2$s The %3$sWooCommerce Subscriptions%4$s version %7$s (or greater) is required to safely run WooCommerce Subscriptions Importer. Please %5$supdate & activate%6$s WooCommerce Subscriptions.', 'wcs-import-export' ), '<strong>', '</strong>', '<a href="http://www.woocommerce.com/products/woocommerce-subscriptions/">', '</a>', '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '&nbsp;&raquo;</a>', self::$required_subscriptions_version ); ?></p>
+				<p><?php printf( esc_html__( '%1$sWooCommerce Subscriptions CSV Importer and Exporter is inactive.%2$s The %3$sWooCommerce Subscriptions%4$s version %7$s (or greater) is required to safely run WooCommerce Subscriptions CSV Importer and Exporter. Please %5$supdate & activate%6$s WooCommerce Subscriptions.', 'wcs-import-export' ), '<strong>', '</strong>', '<a href="http://www.woocommerce.com/products/woocommerce-subscriptions/">', '</a>', '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '&nbsp;&raquo;</a>', self::$required_subscriptions_version ); ?></p>
 			</div>
 		<?php endif;
 	}

--- a/wcs-importer-exporter.php
+++ b/wcs-importer-exporter.php
@@ -115,7 +115,7 @@ class WCS_Importer_Exporter {
 		if ( ! class_exists( 'WC_Subscriptions' ) || ! class_exists( 'WC_Subscriptions_Admin' ) ) :
 			if ( is_woocommerce_active() ) : ?>
 				<div id="message" class="error">
-					<p><?php printf( esc_html__( '%1$sWooCommerce Subscriptions CSV Importer and Exporter is inactive.%2$s The %3$sWooCommerce Subscriptions plugin%4$s must be active for WooCommerce Subscriptions CSV Importer and Exporter to work. Please %5$sinstall & activate%6$s WooCommerce.', 'wcs-import-export' ), '<strong>', '</strong>', '<a href="http://www.woocommerce.com/products/woocommerce-subscriptions/">', '</a>', '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '</a>' ); ?></p>
+					<p><?php printf( esc_html__( '%1$sWooCommerce Subscriptions CSV Importer and Exporter is inactive.%2$s The %3$sWooCommerce Subscriptions plugin%4$s must be active for WooCommerce Subscriptions CSV Importer and Exporter to work. Please %5$sinstall & activate%6$s WooCommerce Subscriptions.', 'wcs-import-export' ), '<strong>', '</strong>', '<a href="http://www.woocommerce.com/products/woocommerce-subscriptions/">', '</a>', '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '</a>' ); ?></p>
 				</div>
 			<?php else : ?>
 				<div id="message" class="error">


### PR DESCRIPTION
1. Fatal errors occur during the subscription import process.
2. To resolve fatal errors, added a check if the function mb_detect_encoding exists. The function is not found if the 'mbstring' extension is not installed on the server.
3. Added check if the function utf8_encode exists. The function is not found if the 'php-xml' extension is not installed on the server.
