### PR TITLE
Hash file names and add index.php & .htaccess to the directory we use for storing exports

### DIFF
--- a/includes/class-wcs-export-admin.php
+++ b/includes/class-wcs-export-admin.php
@@ -281,9 +281,9 @@ class WCS_Export_Admin {
 
 		if ( !empty($files) ) {
 
-			$files = array_diff($files, array('.', '..'));
+			$files      = array_diff( $files, array('.', '..', 'index.php', '.htaccess' ) );
 			$upload_dir = wp_upload_dir();
-			$files_url = $upload_dir['baseurl'] . '/woocommerce-subscriptions-importer-exporter/';
+			$files_url  = $upload_dir['baseurl'] . '/woocommerce-subscriptions-importer-exporter/';
 
 			foreach ( $files as $file ) {
 
@@ -478,9 +478,7 @@ class WCS_Export_Admin {
 		);
 
 		// Create directory if it does not exist and create the file.
-		if ( !file_exists(WCS_Exporter_Cron::$cron_dir) ) {
-			mkdir(WCS_Exporter_Cron::$cron_dir, 0775);
-		}
+		WCS_Exporter_Cron::create_upload_directory();
 
 		$file_path = WCS_Exporter_Cron::$cron_dir . '/' . $post_data['filename'];
 		$file = fopen($file_path, 'a');

--- a/includes/class-wcs-export-admin.php
+++ b/includes/class-wcs-export-admin.php
@@ -460,9 +460,11 @@ class WCS_Export_Admin {
 		$post_data = $_POST;
 
 		// add tmp and timestamp to filename.
-		$filename = $post_data['filename'];
+		$filename       = $post_data['filename'];
 		$file_extension = pathinfo($filename, PATHINFO_EXTENSION);
-		$post_data['filename'] = str_replace('.' . $file_extension, '', $filename) . '-' . time() . '.tmp.' . $file_extension;
+		$handle         = str_replace('.' . $file_extension, '', $filename );
+
+		$post_data['filename'] = $handle . '-' . time() . '-' . wp_hash( $handle ) . '.tmp.' . $file_extension;
 
 		// set the initial limit
 		$post_data['limit'] = $post_data['limit_batch'] != '' ? $post_data['limit_batch'] : 500;

--- a/includes/class-wcs-exporter-cron.php
+++ b/includes/class-wcs-exporter-cron.php
@@ -19,9 +19,7 @@ class WCS_Exporter_Cron {
 	 */
     public static function cron_handler( $post_data, $headers ) {
 
-        if ( !file_exists(self::$cron_dir) ) {
-            mkdir(self::$cron_dir, 0775);
-        }
+		self::create_upload_directory();
 
         $done_export = false;
 
@@ -150,4 +148,25 @@ class WCS_Exporter_Cron {
         }
     }
 
+	/**
+	 * Creates upload directory. Does nothing if directory and index/htaccess files already exist
+	 *
+	 * @since 2.1
+	 * @return void
+	 */
+	public static function create_upload_directory() {
+		$base = self::$cron_dir;
+
+		if ( wp_mkdir_p( $base ) ) {
+			// create an empty index.php
+			if ( ! file_exists( $base . '/index.php' ) ) {
+				file_put_contents( $base . '/index.php', '' );
+			}
+
+			// create a .htaccess file with "deny from all" command
+			if ( ! file_exists( $base . '/.htaccess' ) ) {
+				file_put_contents( $base . '/.htaccess', 'Deny from all' );
+			}
+		}
+	}
 }

--- a/includes/class-wcs-import-admin.php
+++ b/includes/class-wcs-import-admin.php
@@ -545,6 +545,10 @@ class WCS_Import_Admin {
 			);
 
 			if ( 'upload_file' == $_POST['action'] ) {
+				// Make sure the uploaded filename is hashed
+				if ( ! empty( $_FILES['import']['name'] ) ) {
+					$_FILES['import']['name'] = sanitize_file_name( wp_hash( $_FILES['import']['name'] ) );
+				}
 
 				$file = wp_import_handle_upload();
 


### PR DESCRIPTION
1718ea3 - Similarly to what is [done in core](https://github.com/woocommerce/woocommerce/blob/3bf473517d407ae46264e0081dfeafedbcce68d6/includes/class-wc-install.php#L1192) this commit make sure the directory we create for storing exports has index and .htaccess files


4d40c9f - hashes export file names using a similar structure to WC log filenames
 - `{filename user chose}-{timestamp}-{hash}.csv`


f58afcf - hashes the name of the file uploaded during the first step of Importing

cc @menakas @thenbrent 

Fixes #217 