### PR TITLE
Remove imported and exported files automatically after they've been used

### DIFF
--- a/includes/class-wcs-export-admin.php
+++ b/includes/class-wcs-export-admin.php
@@ -293,18 +293,11 @@ class WCS_Export_Admin {
 					$status = 'processing';
 				}
 
-				// set date and time
-				$date = '-';
-				$timestamp = absint(substr($file, strpos($file, '-') + 1, 10));
-				if ( strlen($timestamp) == 10 ) {
-					$date = date('d/m/Y G:i:s', absint($timestamp));
-				}
-
 				$file_data = array(
-					'name' => $file,
-					'url' => $files_url . $file,
+					'name'   => $file,
+					'url'    => $files_url . $file,
 					'status' => $status,
-					'date' => $date
+					'date'   => date( 'd/m/Y G:i:s', absint( filectime( trailingslashit( WCS_Exporter_Cron::$cron_dir ) . $file ) ) ),
 				);
 
 				$files_data[] = $file_data;

--- a/includes/class-wcs-export-admin.php
+++ b/includes/class-wcs-export-admin.php
@@ -457,7 +457,7 @@ class WCS_Export_Admin {
 		$file_extension = pathinfo($filename, PATHINFO_EXTENSION);
 		$handle         = str_replace('.' . $file_extension, '', $filename );
 
-		$post_data['filename'] = $handle . '-' . time() . '-' . wp_hash( $handle ) . '.tmp.' . $file_extension;
+		$post_data['filename'] = $handle . '-' . wp_hash( time() . $handle ) . '.tmp.' . $file_extension;
 
 		// set the initial limit
 		$post_data['limit'] = $post_data['limit_batch'] != '' ? $post_data['limit_batch'] : 500;

--- a/includes/class-wcs-export-admin.php
+++ b/includes/class-wcs-export-admin.php
@@ -487,6 +487,7 @@ class WCS_Export_Admin {
 		fclose($file);
 
 		wp_schedule_single_event( time() + 60, 'wcs_export_cron', $event_args );
+		wp_schedule_single_event( time() + WEEK_IN_SECONDS, 'wcs_export_scheduled_cleanup', array( $post_data['filename'] ) );
 	}
 
 	/**

--- a/includes/class-wcs-exporter-cron.php
+++ b/includes/class-wcs-exporter-cron.php
@@ -130,14 +130,13 @@ class WCS_Exporter_Cron {
 	}
 
     /**
-	 * Delete subscription export file.
+	 * Delete subscription export file, including the tmp file if it exists.
 	 *
 	 * @since 2.0-beta
 	 * @param string $file_name
 	 * @return array
 	 */
     public static function delete_export_file( $file_name )  {
-
         if ( $file_name == '' ) {
             return;
         }
@@ -146,6 +145,10 @@ class WCS_Exporter_Cron {
         if ( file_exists($file_path) ) {
             unlink($file_path);
         }
+
+		if ( false !== strpos( $file_name, '.tmp' ) && file_exists( $file_path = str_replace( '.tmp', '', $file_path ) ) ) {
+			unlink( $file_path );
+		}
     }
 
 	/**

--- a/wcs-importer-exporter.php
+++ b/wcs-importer-exporter.php
@@ -64,6 +64,7 @@ class WCS_Importer_Exporter {
 		add_filter( 'plugins_loaded', __CLASS__ . '::setup_importer' );
 		add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), __CLASS__ . '::action_links' );
 		add_action( 'wcs_export_cron', array( 'WCS_Exporter_Cron', 'cron_handler' ), 10, 2 );
+		add_action( 'wcs_export_scheduled_cleanup', array( 'WCS_Exporter_Cron', 'delete_export_file' ), 10, 1 );
 
 		spl_autoload_register( __CLASS__ . '::autoload' );
 	}


### PR DESCRIPTION
66f2409 - Deletes the imported files 2 days after they were created.

The reason for deleting them after 2 days is because some imports can be big and slow enough to go over a day (I recall Brents computer staying awake for ages while doing an import)

c4b502e - Deletes exported files that are exported via Cron and stored in /uploads/
[Brent mentioned](https://a8c.slack.com/archives/CJTS771PB/p1586841541167100) it would be nice to not rely on the plugin being active in order for these to be deleted but since there's no file_id stored for these in the DB we can't use the `importer_scheduled_cleanup` method for exported files.

@menakas can you please review this one 😄 

I think this is a good baseline. Some other things we can look at:

- when the user downloads their exported subscriptions file, we could prompt them to delete the file
- once the import is complete, remove the file straight away instead of waiting 2 days (other importers don't do this, but just an idea)

Thanks