### PR TITLE
WC 4.4.1 Compatibility Bump

### DIFF
--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -467,7 +467,7 @@ class WCS_Importer {
 
 					if ( self::$add_memberships ) {
 						foreach ( $order_items as $product_id ) {
-							self::maybe_add_memberships( $user_id, $subscription->id, $product_id );
+							self::maybe_add_memberships( $user_id, $subscription->get_id(), $product_id );
 						}
 					}
 				}

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -379,7 +379,7 @@ class WCS_Importer {
 					}
 
 					if ( $set_manual || $requires_manual_renewal ) {
-						$subscription->update_manual();
+						$subscription->set_requires_manual_renewal( true );
 					}
 
 					if ( ! empty( $data[ self::$fields['order_notes'] ] ) ) {
@@ -606,7 +606,7 @@ class WCS_Importer {
 				} else {
 					$warnings[] = sprintf( esc_html__( 'The payment method "%s" is either not enabled or does not support the new features of Subscriptions 2.0 and can not be properly attached to your subscription. This subscription has been set to manual renewals.', 'wcs-import-export' ), $payment_method );
 				}
-				$subscription->update_manual();
+				$subscription->set_requires_manual_renewal( true );
 			}
 		}
 		return $warnings;

--- a/wcs-importer-exporter.php
+++ b/wcs-importer-exporter.php
@@ -8,8 +8,8 @@
  * Author URI: http://prospress.com
  * License: GPLv3
  *
- * WC requires at least: 3.0
- * WC tested up to: 3.5
+ * WC requires at least: 3.0.0
+ * WC tested up to: 4.4.1
  *
  * GitHub Plugin URI: Prospress/woocommerce-subscriptions-importer-exporter
  * GitHub Branch: master


### PR DESCRIPTION
This PR bumps the `WC tested up to` header to 4.4.1.

This also does the following:

- replaces the use of the deprecated `WC_Subscription::update_manual` with `WC_Subscription::set_requires_manual_renewal`.
- Replaces direct access of subs ID with call to `get_id()`

I tested this with the latest versions of WC, WC Subs, and WC Memberships.

Closes #223 