### PR TITLE
Update Subscriptions GitHub Repo URL

### DIFF
--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -18,9 +18,4 @@ if [ $1 == 'before' ]; then
 fi
 
 # Install WooCommerce Subscriptions.
-if [[ -n "$GITHUB_TOKEN" ]]; then
-	WCS_GIT_URI="https://$GITHUB_TOKEN@github.com/woocommerce/woocommerce-subscriptions.git"
-else
-	WCS_GIT_URI="git@github.com:woocommerce/woocommerce-subscriptions.git"
-fi
-git clone "$WCS_GIT_URI" "../woocommerce-subscriptions" --branch="${WCS_VERSION}"
+git clone https://$GITHUB_TOKEN@github.com/woocommerce/woocommerce-subscriptions.git "../woocommerce-subscriptions" --branch $WCS_VERSION

--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -8,14 +8,12 @@ say() {
 }
 
 if [ $1 == 'before' ]; then
-
 	# place a copy of woocommerce where the unit tests etc. expect it to be
 	mkdir -p "../woocommerce"
 	curl -L https://api.github.com/repos/woothemes/woocommerce/tarball/$WC_VERSION?access_token=$GITHUB_TOKEN --silent | tar --strip-components=1 -zx -C "../woocommerce"
-
 	say "WooCommerce Installed"
 
+	# Install WooCommerce Subscriptions.
+	git clone https://$GITHUB_TOKEN@github.com/woocommerce/woocommerce-subscriptions.git "../woocommerce-subscriptions" --branch $WCS_VERSION
+	say "WooCommerce Subscriptions Installed"
 fi
-
-# Install WooCommerce Subscriptions.
-git clone https://$GITHUB_TOKEN@github.com/woocommerce/woocommerce-subscriptions.git "../woocommerce-subscriptions" --branch $WCS_VERSION

--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -16,7 +16,7 @@ if [ $1 == 'before' ]; then
 	say "WooCommerce Installed"
 
 	# place a copy of woocommerce subscriptions where the unit tests etc. expect it to be - needs to be a repo with the test dir
-	git clone https://$GITHUB_TOKEN@github.com/Prospress/woocommerce-subscriptions.git "../woocommerce-subscriptions" -b $WCS_VERSION
+	git clone https://$GITHUB_TOKEN@github.com/woocommerce/woocommerce-subscriptions.git "../woocommerce-subscriptions" -b $WCS_VERSION
 
 	say "WooCommerce Subscriptions Installed"
 

--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -23,4 +23,4 @@ if [[ -n "$GITHUB_TOKEN" ]]; then
 else
 	WCS_GIT_URI="git@github.com:woocommerce/woocommerce-subscriptions.git"
 fi
-git clone --depth=1 --branch="${WCS_VERSION}" "$WCS_GIT_URI" "${WP_CORE_DIR}/wp-content/plugins/woocommerce-subscriptions"
+git clone "$WCS_GIT_URI" "../woocommerce-subscriptions" --branch="${WCS_VERSION}"

--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -15,9 +15,12 @@ if [ $1 == 'before' ]; then
 
 	say "WooCommerce Installed"
 
-	# place a copy of woocommerce subscriptions where the unit tests etc. expect it to be - needs to be a repo with the test dir
-	git clone https://$GITHUB_TOKEN@github.com/woocommerce/woocommerce-subscriptions.git "../woocommerce-subscriptions" -b $WCS_VERSION
-
-	say "WooCommerce Subscriptions Installed"
-
 fi
+
+# Install WooCommerce Subscriptions.
+if [[ -n "$GITHUB_TOKEN" ]]; then
+	WCS_GIT_URI="https://$GITHUB_TOKEN@github.com/woocommerce/woocommerce-subscriptions.git"
+else
+	WCS_GIT_URI="git@github.com:woocommerce/woocommerce-subscriptions.git"
+fi
+git clone --depth=1 --branch="${WCS_VERSION}" "$WCS_GIT_URI" "${WP_CORE_DIR}/wp-content/plugins/woocommerce-subscriptions"


### PR DESCRIPTION
Updating it from `Prospress/woocommerce-subscriptions` to `woocommerce/woocommerce-subscriptions`.

Why?
Because currently [the build fails](https://github.com/woocommerce/woocommerce-subscriptions-importer-exporter/pull/225#issuecomment-713525757) and this fix should hopefully get the build to complete without any errors.

Edit: While I wait for the build to complete, I'm not sure whether my changes would work for a private wcs repository. Let's see!