### PR TITLE
Only split/explode the payment meta by ":" once

### DIFF
--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -551,7 +551,8 @@ class WCS_Importer {
 
 				if ( ! empty( $data[ self::$fields['payment_method_post_meta'] ] ) ) {
 					foreach ( explode( '|', $data[ self::$fields['payment_method_post_meta'] ] ) as $meta ) {
-						list( $name, $value ) = explode( ':', $meta );
+						// Some payment gateway meta (like Square), includes a ':' in the token so limit the explode to only split once (2 values).
+						list( $name, $value ) = explode( ':', $meta, 2 );
 						$payment_post_meta[ trim( $name ) ] = trim( $value );
 					}
 				}


### PR DESCRIPTION
**Issue:** #221 

### Description:

Some payment gateway tokens, like Square, include a ':' character in the token itself. When exporting payment gateway data we concatenate the key and meta value with a ':' (see example below) and so splitting the value by ':' resulted in only saving the first half of the token.

This commit ensures we only explode/split the value once so the second half of the key is preserved.

## Steps to test this PR: 

1. Export you're own Square subscriptions (only 1 is needed) via **WooCommerce > Export Subscriptions** making sure to [include the payment data](https://d.pr/i/Sv0lhi) or...
1. Download the test csv here: https://d.pr/f/vvQlJf
      - This csv includes export data for 5 of my Square subscriptions.
      - The data is anonymised.
      - There are no line items exported so you won't need to worry about misaligned product IDs.
      - The subscriptions will be for customer ID 1. 
2. Import the exported csv.
3. The default import mapping should be fine, just make sure the payment meta is correct (https://d.pr/i/t5EUZQ).
4. Import.
5. View the resulting subscription.
     - On `master` the resulting subscription's payment tokens will look like this: https://d.pr/i/xdBDRj
     - On this branch, the full tokens should be imported fully (https://d.pr/i/mbHfOt)