### PR TITLE
Fix incorrect start_date on exported subscriptions

### DIFF
--- a/includes/class-wcs-exporter.php
+++ b/includes/class-wcs-exporter.php
@@ -134,7 +134,7 @@ class WCS_Exporter {
 					}
 					break;
 				case 'start_date':
-					$value = version_compare( WC()->version, '3.0', '>=' ) ? $subscription->get_date( 'date_created' ) : $subscription->start_date;
+					$value = version_compare( WC()->version, '3.0', '>=' ) ? $subscription->get_date( 'start' ) : $subscription->start_date;
 					break;
 				case 'trial_end_date':
 					$value = version_compare( WC()->version, '3.0', '>=' ) ? $subscription->get_date( 'trial_end' ) : $subscription->trial_end_date;


### PR DESCRIPTION
Exporting subscriptions that were previously imported is returning incorrect values for the `start_date` column, with the returned value being the date the subscriptions were imported rather than the start date of the subscription. 

This basic PR changes the call to `WC_Subscription::get_date()` to use `'start'` as the `$date_type` parameter instead of `'date_created'`, which doesn't even appear to be a valid `$date_type`.

Does this perhaps need to fall back to `'date_created'` if the value of `'start'` is empty?