### PR TITLE
Address HPOS compatibility

### DIFF
--- a/includes/class-wcs-export-admin.php
+++ b/includes/class-wcs-export-admin.php
@@ -101,13 +101,20 @@ class WCS_Export_Admin {
 	 * @since 1.0
 	 */
 	public function home_page() {
-
 		$statuses      = wcs_get_subscription_statuses();
 		$status_counts = array();
 
-		foreach ( wp_count_posts( 'shop_subscription' ) as $status => $count ) {
-			if ( array_key_exists( $status, $statuses ) ) {
-				$status_counts[ $status ] = $count;
+		if ( wcsi_is_hpos_enabled() ) {
+			$wcs_datastore = WC_Data_Store::load( 'subscription' );
+
+			foreach ( array_keys( $statuses ) as $status ) {
+				$status_counts[ $status ] = $wcs_datastore->get_order_count( $status );
+			}
+		} else {
+			foreach ( wp_count_posts( 'shop_subscription' ) as $status => $count ) {
+				if ( array_key_exists( $status, $statuses ) ) {
+					$status_counts[ $status ] = $count;
+				}
 			}
 		}
 
@@ -398,10 +405,14 @@ class WCS_Export_Admin {
 		if ( isset( $_POST['payment'] ) && 'any' != $_POST['payment'] ) {
 			$payment_payment = ( 'none' == $_POST['payment'] ) ? '' : $_POST['payment'];
 
-			$query_args['meta_query'][] = array(
-				'key'   => '_payment_method',
-				'value' => $payment_payment,
-			);
+			if ( wcsi_is_hpos_enabled() ) {
+				$query_args['payment_method'] = $payment_payment;
+			} else {
+				$query_args['meta_query'][] = array(
+					'key'   => '_payment_method',
+					'value' => $payment_payment,
+				);
+			}
 		}
 
 		return $query_args;

--- a/includes/class-wcs-exporter-cron.php
+++ b/includes/class-wcs-exporter-cron.php
@@ -85,11 +85,7 @@ class WCS_Exporter_Cron {
 		);
 
 		if ( ! empty( $post_data['status'] ) ) {
-			$statuses = array_keys( $post_data['status'] );
-
-			if ( ! empty( $statuses ) && is_array( $statuses ) ) {
-				$args['subscription_status'] = implode( ',', $statuses );
-			}
+			$args['subscription_status'] = array_keys( $post_data['status'] );
 		}
 
 		if ( ! empty( $post_data['customer'] ) && is_numeric( $post_data['customer'] ) ) {

--- a/includes/wcsi-functions.php
+++ b/includes/wcsi-functions.php
@@ -145,3 +145,14 @@ function wcsi_check_customer( $data, $mapped_fields, $test_mode = false, $email_
 
 	return $found_customer;
 }
+
+/**
+ * Checks whether HPOS is in use in WooCommerce.
+ *
+ * @since 2.2.0
+ *
+ * @return bool TRUE if HPOS is enabled, FALSE otherwise.
+ */
+function wcsi_is_hpos_enabled() {
+	return function_exists( 'wcs_is_custom_order_tables_usage_enabled' ) && wcs_is_custom_order_tables_usage_enabled();
+}

--- a/wcs-importer-exporter.php
+++ b/wcs-importer-exporter.php
@@ -41,6 +41,18 @@ if ( ! function_exists( 'woothemes_queue_update' ) || ! function_exists( 'is_woo
 	require_once( 'woo-includes/woo-functions.php' );
 }
 
+/**
+ * Declare plugin compatibility with WooCommerce HPOS.
+ */
+add_action(
+	'before_woocommerce_init',
+	function() {
+		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+		}
+	}
+);
+
 require_once( 'includes/wcsi-functions.php' );
 
 class WCS_Importer_Exporter {


### PR DESCRIPTION
This PR adds compatibility with WooCommerce Core HPOS.


### Testing instructions

1. Make sure WooCommerce Subscriptions is enabled on the test site and there's at least a subscription product available.
2. Enable the HPOS feature in core by going to WC > Settings > Advanced > Features and make sure "Enable the high performance order storage feature." is checked off.
3. Go to WC > Settings > Advanced > Custom Data Stores and make sure "Use the WordPress posts table" is the active option.
4. Add a few test subscriptions to the site either manually or by purchasing the test subscription product from step 1 above.
5. Go to WC > Subscriptions Exporter and perform a few CSV exports (cron and direct) with different configurations.
6. Confirm the resulting CSV looks sane.
7. Delete the test subscriptions from the site (in WC > Subscriptions).
8. Use the CSV from step 5 (or a similar one) in WC > Subscriptions Importer to try out an import.
9. Make sure the subscriptions have been created correctly (billing info matches CSV, dates, etc.) after the import is complete.
10. Go to WC > Settings > Advanced > Custom Data Stores and make sure "Use the WooCommerce orders tables" is selected.
11. Repeat steps 4 to 9.