### PR TITLE
Add installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ To maximize your changes of success with an import, please read through this doc
 
 There is no substitution for this step. Fully understanding the details of the import process will save you time by avoiding mistakes that may become serious issues in the future.
 
+## Installation
+
+[Download the latest zip of the plugin using this link](https://github.com/woocommerce/woocommerce-subscriptions-importer-exporter/archive/refs/heads/master.zip). Install the zip as a WordPress plugin using the plugin uploader.
+
 ## Importer Usage Guide
 
 To import your subscriptions to WooCommerce via CSV, you need to:


### PR DESCRIPTION
Closes #280 

This PR adds installation instructions for this repo to help with the situation of people accidentally downloading and using the official tagged releases, which are out of date and don't work with new versions of WooCommerce/Subscriptions.