### PR TITLE
Add basic composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "woocommerce/woocommerce-subscriptions-importer-exporter",
+    "description": "Import your subscribers to WooCommerce from a CSV. Or export your subscription data from WooCommerce to CSV. ",
+    "type": "wordpress-plugin",
+    "authors": [
+        {
+            "name": "woocommerce"
+        }
+    ]
+}


### PR DESCRIPTION
Allows plugin to be installed via Composer, since it isn't on the WP.org plugin repo.

Also see #280 which directly impacts the usefulness of this.