### PR TITLE
Tag 2.2.0

### DIFF
--- a/changlog.txt
+++ b/changlog.txt
@@ -1,5 +1,11 @@
 *** WooCommerce Subscriptions CSV Importer and Exporter Changelog ***
 
+2024.07.08 - version 2.2.0
+* Add - Support for WooCommerce High Performance Order Storage. PR #262
+* Fix - Replace use of deprecated update_manual. PR #225
+* Fix - Replace direct access of subscription ID. PR #225
+* Fix - Allow importing of cancelled_date and fix handling of end_date. PR #278
+
 2020.04.20 - version 2.1.0
 * Fix fatal errors which occur during the subscription import process. PR#214
 * Add .htaccess and index.php files to the export directory. PR#218

--- a/package.json
+++ b/package.json
@@ -3,16 +3,16 @@
 	"title": "WooCommerce Subscriptions Importer and Exporter",
 	"author": "Prospress",
 	"license": "ISC",
-	"version": "1.0.0",
+	"version": "2.2.0",
 	"description": "",
-	"homepage": "https://github.com/Prospress/woocommerce-subscriptions-importer-exporter",
+	"homepage": "https://github.com/WooCommerce/woocommerce-subscriptions-importer-exporter",
 	"main": "Gruntfile.js",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Prospress/woocommerce-subscriptions-importer-exporter.git"
+		"url": "https://github.com/WooCommerce/woocommerce-subscriptions-importer-exporter.git"
 	},
 	"bugs": {
-		"url": "https://github.com/Prospress/woocommerce-subscriptions-importer-exporter/issues"
+		"url": "https://github.com/WooCommerce/woocommerce-subscriptions-importer-exporter/issues"
 	},
 	"directories": {
 		"test": "tests"

--- a/wcs-importer-exporter.php
+++ b/wcs-importer-exporter.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Subscriptions CSV Importer and Exporter
  * Plugin URI: https://github.com/Prospress/woocommerce-subscriptions-importer-exporter
  * Description: Import or export subscriptions in your WooCommerce store via CSV.
- * Version: 2.1.0
+ * Version: 2.2.0
  * Author: Prospress Inc
  * Author URI: http://prospress.com
  * License: GPLv3
@@ -61,7 +61,7 @@ class WCS_Importer_Exporter {
 
 	public static $wcs_exporter;
 
-	public static $version = '2.0.1';
+	public static $version = '2.2.0';
 
 	protected static $required_subscriptions_version = '2.2.0';
 


### PR DESCRIPTION
Closes #280 

Tags a release with HPOS compatibility to solve for people constantly installing released versions that don't work.