### PR TITLE
Display cron export date as per site preferences

### DIFF
--- a/includes/class-wcs-export-admin.php
+++ b/includes/class-wcs-export-admin.php
@@ -292,6 +292,9 @@ class WCS_Export_Admin {
 			$upload_dir = wp_upload_dir();
 			$files_url  = $upload_dir['baseurl'] . '/woocommerce-subscriptions-importer-exporter/';
 
+			// Get the site's date and time format settings.
+			$datetime_format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
+
 			foreach ( $files as $file ) {
 
 				// set status
@@ -304,7 +307,7 @@ class WCS_Export_Admin {
 					'name'   => $file,
 					'url'    => $files_url . $file,
 					'status' => $status,
-					'date'   => date( 'd/m/Y G:i:s', absint( filectime( trailingslashit( WCS_Exporter_Cron::$cron_dir ) . $file ) ) ),
+					'date'   => date_i18n( $datetime_format, absint( filectime( trailingslashit( WCS_Exporter_Cron::$cron_dir ) . $file ) ) ),
 				);
 
 				$files_data[] = $file_data;


### PR DESCRIPTION
## Description

Instead of displaying the exports in the table with the `d/m/Y G:i:s` format, we prefer to get the date format from the site settings, and display it as the site admin prefers.

## Changes

We are now getting the datetime preferences like this:

```PHP
$datetime_format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
```

And populating the date like this:

```PHP
'date'   => date_i18n( $datetime_format, absint( filectime( trailingslashit( WCS_Exporter_Cron::$cron_dir ) . $file ) ) ),
```

This results in a date displaying per the site format, like this screenshot:
<img width="893" alt="Screenshot 2024-10-08 at 14 19 42" src="https://github.com/user-attachments/assets/53648494-f88b-4d1a-a8f4-4e3ce3a30962">


Closes: #289 