### PR TITLE
Disable issue creation on GH

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: We have moved to Linear!
+    url: https://linear.app/a8c/team/PAY/new?template=e036ac14-e688-4853-b584-0a476b33e58f
+    about: Please open new issues on Linear. If you don't have access to Linear and you want to report an issue, please reach out via Slack.


### PR DESCRIPTION
### Description
With the transition to Linear, GH issues must be created in Linear, rather than in GH, for private repositories.

### Steps to test:
1. Go to Issues 
1. Click on New issue
1. Confirm that a prompt to create the issue on Linear is displayed instead of the template for creating a GH issue.

Part of WOOSUBS-706
